### PR TITLE
Update test names to match core terminology

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,10 @@ jobs:
           command: npm run install-shields
 
       - run:
-          name: Run core tests
+          name: Run main tests
           environment:
             mocha_reporter: mocha-junit-reporter
-            MOCHA_FILE: junit/core/results.xml
+            MOCHA_FILE: junit/main/results.xml
           command: npm run coverage:test
           when: always
       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,10 @@ jobs:
           command: npm run install-shields
 
       - run:
-          name: Run tests
+          name: Run core tests
           environment:
             mocha_reporter: mocha-junit-reporter
-            MOCHA_FILE: junit/app/results.xml
+            MOCHA_FILE: junit/core/results.xml
           command: npm run coverage:test
           when: always
       


### PR DESCRIPTION
I thought we'd need to update the target scripts based on the changes made in https://github.com/badges/shields/pull/2798, but doesn't look like that will be necessary after all. 

I did add the `core` labeling in here to be consistent with the test reports, etc., but let me know if this is an unnecessary change