### PR TITLE
Skip downloading Cypress

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,10 @@ jobs:
       - run:
           name: Install root dependencies
           command: npm ci
+          environment:
+            # https://docs.cypress.io/guides/getting-started/installing-cypress.html#Skipping-installation
+            # We don't need to install the Cypress binary in jobs that aren't actually running Cypress.
+            CYPRESS_INSTALL_BINARY: 0
 
       - run:
           name: Install shields

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,14 +13,14 @@ jobs:
       - run:
           name: Install root dependencies
           command: npm ci
-          environment:
-            # https://docs.cypress.io/guides/getting-started/installing-cypress.html#Skipping-installation
-            # We don't need to install the Cypress binary in jobs that aren't actually running Cypress.
-            CYPRESS_INSTALL_BINARY: 0
 
       - run:
           name: Install shields
           command: npm run install-shields
+          environment:
+            # https://docs.cypress.io/guides/getting-started/installing-cypress.html#Skipping-installation
+            # We don't need to install the Cypress binary in jobs that aren't actually running Cypress.
+            CYPRESS_INSTALL_BINARY: 0
 
       - run:
           name: Run main tests


### PR DESCRIPTION
We do not use Cypress in daily tests so we do not have to install it.
Before this change:
https://circleci.com/gh/badges/daily-tests/647
```
> cypress@3.4.1 postinstall /home/circleci/project/shields/node_modules/cypress
> node index.js --exec install

Installing Cypress (version: 3.4.1)

[03:45:35]  Downloading Cypress     [started]
[03:45:36]  Downloading Cypress     [completed]
[03:45:36]  Unzipping Cypress       [started]
[03:46:00]  Unzipping Cypress       [completed]
[03:46:00]  Finishing Installation  [started]
[03:46:01]  Finishing Installation  [completed]

You can now open Cypress by running: node_modules/.bin/cypress open

https://on.cypress.io/installing-cypress
```

After this change:
https://circleci.com/gh/badges/daily-tests/652
```
> cypress@3.4.1 postinstall /home/circleci/project/shields/node_modules/cypress
> node index.js --exec install

Note: Skipping binary installation: Environment variable CYPRESS_INSTALL_BINARY = 0.
```
We have similar a configuration in Shields: https://github.com/badges/shields/blob/3a6611b19930f05203c17d456e43af8ab5ee1381/.circleci/config.yml#L13-L19