### PR TITLE
Enable retries for service tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           environment:
             mocha_reporter: mocha-junit-reporter
             MOCHA_FILE: junit/services/results.xml
-          command: npm run coverage:services
+          command: RETRY_COUNT=3 npm run coverage:services
           when: always
 
       - run:


### PR DESCRIPTION
https://github.com/badges/shields/pull/4166 added an option to configure retries. 

I've prepared [a separate branch](https://github.com/badges/shields/compare/service-tests-low-timeout?expand=1) in shields with a low value of timeout and [an extra branch](https://github.com/badges/daily-tests/compare/retry-service-tests-force-retry?expand=1) in daily-tests. Both changes forces retries: https://circleci.com/gh/badges/daily-tests/660.
`R` indicates a retry:
```
 ArchLinux
    [live] Arch Linux package (valid)
R      ✓ 
	[ GET /core/x86_64/pacman.json ] (790ms)
```

```
  14) UptimeRobotRatio
       [live] Uptime Robot: Percentage (valid)
         
	[ GET /m778918918-3e92c097147760ee39d02d36.json ]:
     Error: Request timed out after 500 ms (4 attempts)
      at IcedFrisbyNock.run (node_modules/icedfrisby/lib/icedfrisby.js:1255:37)
      at <anonymous>
```