### PR TITLE
use node 14 for service tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
   daily:
 
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:14
       - image: redis
 
     steps:


### PR DESCRIPTION
Service tests require Node v14 now